### PR TITLE
实现点击Error视图中的某个控件来重试

### DIFF
--- a/loadsir/src/main/java/com/kingja/loadsir/callback/Callback.java
+++ b/loadsir/src/main/java/com/kingja/loadsir/callback/Callback.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 public abstract class Callback implements Serializable {
     private View rootView;
     private Context context;
-    private OnReloadListener onReloadListener;
+    protected OnReloadListener onReloadListener;
     private boolean successViewVisible;
 
     public Callback() {


### PR DESCRIPTION
将Callback接口中private OnReloadListener onReloadListener;   改为protected OnReloadListener onReloadListener;
理由：出现自定义布局界面时，只响应具体控件的点击事件，而不是全部的布局。

虽然可以直接注册View或者onReloadEvent中获取某个空间的id再实现点击逻辑。但是他没有办法把重试的事件响应给业务层。
将 OnReloadListener onReloadListener 返回给Callback的子类就可以了。重新处理点击事件（包括拦截处理）。
